### PR TITLE
Added react-native-web to apply to Webpack only, updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "react-native-web": "^0.6.1",
+    "react-native-web": "^0.8.3",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
@@ -44,7 +44,7 @@
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
-    "babel-plugin-react-native-web": "^0.6.1",
+    "babel-plugin-react-native-web": "^0.8.3",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "electron": "^1.8.4",
     "electron-packager": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/react-everywhere/re-start/issues",
   "dependencies": {
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
     "react-native-web": "^0.8.3",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",

--- a/templates/re-base/finishInstall.js
+++ b/templates/re-base/finishInstall.js
@@ -7,9 +7,6 @@ const {existsSync, readFileSync, renameSync, unlinkSync, writeFileSync} = requir
 const {basename, resolve} = require('path');
 
 
-const install = "node scripts/install.js"
-
-
 /**
  * Use Yarn if available, it's much faster than the npm client.
  * Return the version of yarn installed on the system, null if yarn is not available.
@@ -103,7 +100,7 @@ function updatePackageJson() {
       "electron": "electron build",
       "electron:release": "electron-packager build --all --asar --icon=/tmp/app --overwrite --out=electron",
       "icon-gen": "icon-gen -i resources/icon.svg -o /tmp && cp /tmp/favicon-228.png /tmp/app.png && mv /tmp/favicon* public",
-      "install": install,
+      "install": "node scripts/install.js",
       "ios": "react-native run-ios",
       "ios:release": "react-native bundle --platform=ios",
       "preandroid": "scripts/preandroid.sh",

--- a/templates/re-base/finishInstall.js
+++ b/templates/re-base/finishInstall.js
@@ -59,10 +59,6 @@ function enableWindows() {
     unlinkSync(resolve('App.windows.js'))
 }
 
-function enableBabelrc() {
-  execSync(install);
-}
-
 function moveAppJs() {
   const src  = resolve('App.js')
   const dest = resolve('src', 'App.js')
@@ -128,7 +124,6 @@ function updatePackageJson() {
 
 installDevDependencies();
 enableWindows();
-enableBabelrc();
 moveAppJs();
 updateGitIgnore();
 updatePackageJson();

--- a/templates/re-base/finishInstall.js
+++ b/templates/re-base/finishInstall.js
@@ -6,6 +6,10 @@ const {execSync} = require('child_process');
 const {existsSync, readFileSync, renameSync, unlinkSync, writeFileSync} = require('fs');
 const {basename, resolve} = require('path');
 
+
+const install = "node scripts/install.js"
+
+
 /**
  * Use Yarn if available, it's much faster than the npm client.
  * Return the version of yarn installed on the system, null if yarn is not available.
@@ -48,26 +52,15 @@ function installDevDependencies() {
     unlinkSync(devDependenciesJsonPath);
 }
 
-// Add `react-native-web` plugin to `.babelrc` file
-function updateBabelrc() {
-  const file = './.babelrc'
-  const babelrc = JSON.parse(readFileSync(file))
-
-  let {plugins} = babelrc
-  if(!plugins) plugins = []
-
-  plugins.push('react-native-web')
-
-  babelrc.plugins = plugins
-
-  writeFileSync(file, JSON.stringify(babelrc, null, 2)+'\n')
-}
-
 function enableWindows() {
     console.log('Enable Windows support to the project...');
     execSync(`react-native windows`);
 
     unlinkSync(resolve('App.windows.js'))
+}
+
+function enableBabelrc() {
+  execSync(install);
 }
 
 function moveAppJs() {
@@ -106,7 +99,7 @@ function updatePackageJson() {
       "android": "react-native run-android",
       "android:clean": "cd android && ./gradlew clean",
       "android:dev_menu": "adb shell input keyevent KEYCODE_MENU",
-      "android:emulator": "node scripts/android:emulator.sh",
+      "android:emulator": "scripts/android:emulator.sh",
       "android:kill_server": "fuser -k 8081/tcp || true",
       "android:log": "react-native log-android",
       "android:release": "cd android && ./gradlew assembleRelease",
@@ -114,10 +107,10 @@ function updatePackageJson() {
       "electron": "electron build",
       "electron:release": "electron-packager build --all --asar --icon=/tmp/app --overwrite --out=electron",
       "icon-gen": "icon-gen -i resources/icon.svg -o /tmp && cp /tmp/favicon-228.png /tmp/app.png && mv /tmp/favicon* public",
-      "install": "node scripts/install.js",
+      "install": install,
       "ios": "react-native run-ios",
       "ios:release": "react-native bundle --platform=ios",
-      "preandroid": "node scripts/preandroid.sh",
+      "preandroid": "scripts/preandroid.sh",
       "preelectron": "PUBLIC_URL=. npm run web:release && cp index.electron.js build/index.js && echo {} > build/package.json",
       "preelectron:release": "npm run preelectron",
       "preweb:release": "npm run icon-gen",
@@ -134,8 +127,8 @@ function updatePackageJson() {
 
 
 installDevDependencies();
-updateBabelrc();
 enableWindows();
+enableBabelrc();
 moveAppJs();
 updateGitIgnore();
 updatePackageJson();

--- a/templates/re-base/package.json
+++ b/templates/re-base/package.json
@@ -27,8 +27,8 @@
   },
   "version": "0.3.2",
   "dependencies": {
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
-    "react-native-web": "^0.6.1"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
+    "react-native-web": "^0.8.3"
   }
 }

--- a/templates/re-base/scripts/install.js
+++ b/templates/re-base/scripts/install.js
@@ -3,7 +3,7 @@
 const {readFileSync, writeFileSync} = require('fs')
 
 
-// Enable `react-native-web` in webpackage by directly modifying files in `react-scripts`
+// Enable `react-native-web` in webpack by directly modifying files in `react-scripts`
 const files =
 [
   'jest/babelTransform',
@@ -16,5 +16,5 @@ files.forEach(function(name)
   const path = `node_modules/react-scripts/config/${name}.js`
   const data = readFileSync(path, 'utf8')
 
-  writeFileSync(path, data.replace('babelrc: true,', 'babelrc: true,\nplugins: [\'react-native-web\'],'))
+  writeFileSync(path, data.replace('babelrc: false,', 'babelrc: false,\nplugins: [\'react-native-web\'],'))
 })

--- a/templates/re-base/scripts/install.js
+++ b/templates/re-base/scripts/install.js
@@ -3,7 +3,7 @@
 const {readFileSync, writeFileSync} = require('fs')
 
 
-// Enable `.babelrc` file support in `react-scripts`
+// Enable `react-native-web` in webpackage by directly modifying files in `react-scripts`
 const files =
 [
   'jest/babelTransform',
@@ -16,5 +16,5 @@ files.forEach(function(name)
   const path = `node_modules/react-scripts/config/${name}.js`
   const data = readFileSync(path, 'utf8')
 
-  writeFileSync(path, data.replace('babelrc: false', 'babelrc: true'))
+  writeFileSync(path, data.replace('babelrc: true,', 'babelrc: true,\nplugins: [\'react-native-web\'],'))
 })


### PR DESCRIPTION
This fixes the "Could not get BatchedBridge" error when running the native applications.

Also updated react-native-web to use 0.8.3 for react-native 0.55 compatibility. 